### PR TITLE
Initial implementation of livestreamer config files

### DIFF
--- a/src/livedumper_cli
+++ b/src/livedumper_cli
@@ -4,8 +4,10 @@ import os
 import sys
 from argparse import ArgumentParser
 
+import appdirs
 from livedumper.dumper import LivestreamerDumper
 
+__appname__ = 'livedumper'
 __author__ = 'Thiago Kenji Okada'
 __version__ = '0.1.5'
 
@@ -30,7 +32,11 @@ def main():
     # Parse the user choices
     args = parser.parse_args()
 
-    dumper = LivestreamerDumper()
+    config_path = appdirs.user_config_dir(__appname__)
+    if not os.path.exists(config_path):
+        os.mkdir(config_path)
+    dumper = LivestreamerDumper(config_path)
+    
     for video_url in args.url:
         dumper.open(video_url, args.quality)
         # I am assuming that all videos are using mp4 format, may be wrong


### PR DESCRIPTION
It only supports global configuration for now instead of configuration
per plugin (needs to investigate how ConfigParser really works, and for
some motive livestreamer.set_plugin_option() isn't working), and doesn't
support both types from options that has 2 different types (I am only
supporting the str variation). But it seems to work (tested on both
Python 3.4 and 2.7).
