### PR TITLE
If no exit msg is given, exit with success status.

### DIFF
--- a/src/livedumper/dumper.py
+++ b/src/livedumper/dumper.py
@@ -197,7 +197,7 @@ class LivestreamerDumper(object):
 
         self.fd = None
 
-    def exit(self, msg=''):
+    def exit(self, msg=0):
         "Close an opened stream and call sys.exit(msg)."
 
         self.stop()


### PR DESCRIPTION
sys.exit('') means to exit with failure status, so the default argument
should be 0. Otherwise, a successfully completed download results in
apparent failure, because livedumper_cli invokes dumper.exit() on
completion.

Fix issue #11
